### PR TITLE
[scan] scan dim handling in user-facing scan()

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -2910,8 +2910,11 @@ def forward(self, pred_1, x_1):
             return c_new, h_new
 
         with self.assertRaisesRegex(
-            RuntimeError,
-            "All xs leaves must at least have.*",
+            # Should be
+            # RuntimeError,
+            # "All xs leaves must at least have.*",
+            torch._dynamo.exc.Unsupported,
+            "Observed exception.*",
         ):
             result = scan(RNN, h, [x, W_ih, b_ih, W_hh, b_hh], dim=2, reverse=reverse)
 
@@ -3179,13 +3182,13 @@ def forward(self, pred_1, x_1):
             """\
 def forward(self, fct_1, init_1, xs_1):
     permute = torch.ops.aten.permute.default(xs_1, [0, 1, 2]);  xs_1 = None
-    select = torch.ops.aten.select.int(permute, 0, 0)
-    add = torch.ops.aten.add.Tensor(init_1, select);  add = None
-    add_1 = torch.ops.aten.add.Tensor(init_1, select);  select = add_1 = None
+    select_copy = torch.ops.aten.select_copy.int(permute, 0, 0)
+    add = torch.ops.aten.add.Tensor(init_1, select_copy);  add = None
+    add_1 = torch.ops.aten.add.Tensor(init_1, select_copy);  select_copy = add_1 = None
     clone = torch.ops.aten.clone.default(init_1);  clone = None
-    select_copy = torch.ops.aten.select_copy.int(permute, 0, 0);  select_copy = None
+    select_copy_1 = torch.ops.aten.select_copy.int(permute, 0, 0);  select_copy_1 = None
     scan_combine_graph_0 = self.scan_combine_graph_0
-    scan = torch.ops.higher_order.scan(scan_combine_graph_0, [init_1], [permute], 0, True, []);  scan_combine_graph_0 = init_1 = permute = None
+    scan = torch.ops.higher_order.scan(scan_combine_graph_0, [init_1], [permute], True, []);  scan_combine_graph_0 = init_1 = permute = None
     getitem = scan[0]
     getitem_1 = scan[1];  scan = None
     return (getitem, getitem_1)""",  # noqa: B950
@@ -3203,13 +3206,13 @@ def forward(self, L_init_ : torch.Tensor, L_xs_ : torch.Tensor):
     l_init_ = L_init_
     l_xs_ = L_xs_
     elem = torch.movedim(l_xs_, 0, 0);  l_xs_ = None
-    select = elem.select(0, 0)
-    out_l = l_init_ + select;  out_l = None
-    add_1 = l_init_ + select;  select = add_1 = None
+    select_copy = torch.select_copy(elem, 0, 0)
+    out_l = l_init_ + select_copy;  out_l = None
+    add_1 = l_init_ + select_copy;  select_copy = add_1 = None
     child = l_init_.clone();  child = None
     child_1 = torch.select_copy(elem, 0, 0);  child_1 = None
     scan_combine_fn_0 = self.scan_combine_fn_0
-    scan = torch.ops.higher_order.scan(scan_combine_fn_0, [l_init_], [elem], 0, True, []);  scan_combine_fn_0 = l_init_ = elem = None
+    scan = torch.ops.higher_order.scan(scan_combine_fn_0, [l_init_], [elem], True, []);  scan_combine_fn_0 = l_init_ = elem = None
     getitem = scan[0]
     getitem_1 = scan[1];  scan = None
     return (getitem, getitem_1)""",  # noqa: B950

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1156,10 +1156,10 @@ class ScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
 
         args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
 
-        def arg_extractor(combine_fn, init, xs, dim, reverse, additional_inputs):
-            return combine_fn, init, xs, dim, reverse, additional_inputs
+        def arg_extractor(combine_fn, init, xs, reverse, additional_inputs):
+            return combine_fn, init, xs, reverse, additional_inputs
 
-        combine_fn, init, xs, dim, reverse, additional_inputs = arg_extractor(
+        combine_fn, init, xs, reverse, additional_inputs = arg_extractor(
             *args, **kwargs
         )
         assert isinstance(additional_inputs, variables.BaseListVariable)
@@ -1175,12 +1175,8 @@ class ScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
             )
         assert isinstance(init, variables.BaseListVariable)
 
-        dim_fake = (
-            dim.as_proxy()
-            if type(dim.as_proxy()) == int
-            else get_fake_value(dim.as_proxy().node, tx)
-        )
-        scan_length = get_fake_value(xs.items[0].as_proxy().node, tx).size()[dim_fake]
+        # The scan dim is always 0, thus the scan length is also determined from dim 0
+        scan_length = get_fake_value(xs.items[0].as_proxy().node, tx).size()[0]
         if scan_length == 0:
             unimplemented(
                 "scan() operator doesn't support zero-sized tensors during tracing."
@@ -1199,7 +1195,8 @@ class ScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
         # The sub_args_inp is a slice of original input, e.g. if input.size is (3, 4), and scan dim=0
         # the sub_args_inp shape will be (4, ).
         sub_args_inp = [
-            _make_inlined(tx, first_slice_copy)(inp, dim) for inp in xs.items
+            _make_inlined(tx, first_slice_copy)(inp, ConstantVariable.create(0))
+            for inp in xs.items
         ]
         sub_args_additional_inputs = [
             t.call_method(tx, "clone", args=(), kwargs={})
@@ -1275,7 +1272,6 @@ class ScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
             make_attr(tx, combine_fn_name),
             init_proxy,
             xs_proxy,
-            dim.as_proxy(),
             reverse.as_proxy(),
             additional_inputs_proxy,
         )

--- a/torch/_higher_order_ops/scan.py
+++ b/torch/_higher_order_ops/scan.py
@@ -269,6 +269,8 @@ def scan(
         raise RuntimeError("All init leaves must be a Tensor")
     if any(not isinstance(x, torch.Tensor) for x in leaves_xs):
         raise RuntimeError("All xs leaves must be a Tensor")
+    if any(x.ndim < dim for x in leaves_xs):
+        raise RuntimeError("All xs leaves must at least have 'dim' number of dimensions")
     if any(x.shape[dim] == 0 for x in leaves_xs):
         raise RuntimeError("All xs leaves must have a scan dimension > 0")
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6698,7 +6698,6 @@ class SequentialScan(ExternKernel):
         combine_subgraph: Subgraph,
         init: List[TensorBox],
         xs: List[TensorBox],
-        dim: int,
         reverse: bool,
         additional_inputs: List[TensorBox],
         layout: MultiOutputLayout,
@@ -6706,7 +6705,6 @@ class SequentialScan(ExternKernel):
         self.combine_subgraph = combine_subgraph
         self.init = init
         self.xs = xs
-        self.dim = dim
         self.reverse = reverse
         self.additional_inputs = additional_inputs
 
@@ -6725,7 +6723,6 @@ class SequentialScan(ExternKernel):
         combine_subgraph: Subgraph,
         init: List[TensorBox],
         xs: List[TensorBox],
-        dim: int,
         reverse: bool,
         additional_inputs: List[TensorBox],
     ):
@@ -6734,7 +6731,9 @@ class SequentialScan(ExternKernel):
         num_init_leaves = len(init)
         init = [cls.realize_input(x) for x in init]
         xs = [cls.realize_input(x) for x in xs]
-        scan_length = xs[0].get_size()[dim]
+
+        # The scan dim is always 0, thus the scan length is also determined from dim 0
+        scan_length = xs[0].get_size()[0]
         additional_inputs = [cls.realize_input(x) for x in additional_inputs]
         all_inputs = init + xs + additional_inputs
 
@@ -6750,7 +6749,7 @@ class SequentialScan(ExternKernel):
         # make sure init and outputs are structurally equivalent
         assert len(carry) == num_init_leaves, (init, carry)
         for i, (ini, c) in enumerate(zip(init, carry)):
-            assert ini.get_size() == c.get_size(), (i, ini, c, dim)
+            assert ini.get_size() == c.get_size(), (i, ini, c)
             # assume all init and outputs are on the same device
             # as the MultiOutputLayout below requires single device
             assert ini.get_device() == c.get_device() == device, (i, ini, c, device)
@@ -6760,7 +6759,6 @@ class SequentialScan(ExternKernel):
             combine_subgraph=combine_subgraph,
             init=init,
             xs=xs,
-            dim=dim,
             reverse=reverse,
             additional_inputs=additional_inputs,
             layout=MultiOutputLayout(device),

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6225,7 +6225,7 @@ def while_loop(cond_fn, body_fn, carried_inputs, additional_inputs):
 
 
 @register_lowering(scan_op)
-def scan(combine_subgraph, init, inputs, dim, reverse, additional_inputs):
+def scan(combine_subgraph, init, inputs, reverse, additional_inputs, dim=0):
     from torch._higher_order_ops.scan import _extract_carry_and_out, stack_y
 
     num_init_leaves = len(init)
@@ -6235,8 +6235,8 @@ def scan(combine_subgraph, init, inputs, dim, reverse, additional_inputs):
             msg = f"{msg} Found from : \n {stack_trace}"
         V.graph.disable_cudagraphs_reason = msg
 
-    def extract_scan_args(combine_subraph, init, xs, dim, reverse, additional_inputs):
-        return combine_subraph, init, xs, dim, reverse, additional_inputs
+    def extract_scan_args(combine_subraph, init, xs, reverse, additional_inputs):
+        return combine_subraph, init, xs, reverse, additional_inputs
 
     def _to_out_variant_graph(
         gm: torch.fx.GraphModule,
@@ -6268,7 +6268,7 @@ def scan(combine_subgraph, init, inputs, dim, reverse, additional_inputs):
         return gm
 
     if combine_subgraph.graph is None:
-        _, fx_init, fx_xs, _, _, fx_additional_inputs = extract_scan_args(
+        _, fx_init, fx_xs, _, fx_additional_inputs = extract_scan_args(
             *V.graph.current_node.args
         )
 
@@ -6306,7 +6306,7 @@ def scan(combine_subgraph, init, inputs, dim, reverse, additional_inputs):
             combine_subgraph.graph.run(*example_inputs)  # type: ignore[arg-type]
 
     result = ir.SequentialScan.create(
-        combine_subgraph, init, inputs, dim, reverse, additional_inputs
+        combine_subgraph, init, inputs, reverse, additional_inputs
     )
     return list(map(TensorBox.create, result))
 


### PR DESCRIPTION
This PR introduces the capability that the scan dim is handled in the user facing `scan()` call. Internally, the scan dim is always shifted to dim 0 and then the scan is performed over that dim.

cc @ydwu4 
